### PR TITLE
fs,nova: fix kernel hang when there is less space left

### DIFF
--- a/fs/nova/dir.c
+++ b/fs/nova/dir.c
@@ -626,8 +626,7 @@ static int nova_readdir_fast(struct file *file, struct dir_context *ctx)
 
 	if (sih->log_head == 0) {
 		nova_err(sb, "Dir %lu log is NULL!\n", inode->i_ino);
-		BUG();
-		return -EINVAL;
+		return -ENOSPC;
 	}
 
 	pos = ctx->pos;

--- a/fs/nova/namei.c
+++ b/fs/nova/namei.c
@@ -510,8 +510,10 @@ static int nova_mkdir(struct inode *dir, struct dentry *dentry, umode_t mode)
 	}
 
 	pi = nova_get_inode(sb, inode);
-	nova_append_dir_init_entries(sb, pi, inode->i_ino, dir->i_ino,
+	err = nova_append_dir_init_entries(sb, pi, inode->i_ino, dir->i_ino,
 					epoch_id);
+	if (IS_ERR_VALUE(err))
+		goto out_err;
 
 	/* Build the dir tree */
 	si = NOVA_I(inode);

--- a/fs/nova/rebuild.c
+++ b/fs/nova/rebuild.c
@@ -611,7 +611,7 @@ int nova_rebuild_dir_inode_tree(struct super_block *sb,
 	curr_p = sih->log_head;
 	if (curr_p == 0) {
 		nova_err(sb, "Dir %llu log is NULL!\n", ino);
-		BUG();
+		ret = -ENOSPC;
 		goto out;
 	}
 


### PR DESCRIPTION
    fs,nova: fix kernel panic when there is less space left

    when there is less space on nova fs, nova_append_dir_init_entries will
    return fail and nova_mkdir ignore the return value,
    nova_rebuild_dir_inode_tree read the zero log_head, cause BUG and panic
    Just add dealing with the return value

[ 1285.604322] nova error:
[ 1285.604325] ERROR: no inode log page available: 1 -28
[ 1285.604326] nova error:
[ 1285.604327] ERROR: no inode log page available
[ 1285.604330] nova error:
[ 1285.604331] Dir 95 log is NULL!
[ 1285.604348] ------------[ cut here ]------------
[ 1285.604350] kernel BUG at fs/nova/rebuild.c:614!
[ 1285.604354] invalid opcode: 0000 [#1] SMP
[ 1285.604356] Modules linked in: loop ipt_MASQUERADE
nf_nat_masquerade_ipv4 iptable_nat nf_conntrack_ipv4 nf_defrag_ipv4
nf_nat_ipv4 xt_addrtype iptable_filter xt_conntrack nf_nat nf_conntrack
br_netfilter overlay veth bridge stp llc bonding intel_rapl iosf_mbi
x86_pkg_temp_thermal intel_powerclamp coretemp kvm_intel kvm irqbypass
crct10dif_pclmul crc32_pclmul ghash_clmulni_intel pcbc dax_pmem iTCO_wdt
aesni_intel device_dax crypto_simd nd_pmem glue_helper
iTCO_vendor_support nd_btt ses nd_e820 cryptd i2c_i801 mei_me enclosure
ipmi_si lpc_ich pcspkr ipmi_devintf mfd_core mei sg ipmi_msghandler
shpchp wmi ip_tables ext4 mbcache jbd2 sd_mod ast drm_kms_helper
syscopyarea sysfillrect sysimgblt fb_sys_fops ttm drm igb isci mpt3sas
ptp pps_core libsas dca i2c_algo_bit i2c_core crc32c_intel raid_class
scsi_transport_sas
[ 1285.604418]  ahci libahci libata
[ 1285.604425] CPU: 10 PID: 16442 Comm: mkdir Not tainted 4.13.0+ #4
[ 1285.604426] Hardware name: Inspur SA5212H2/YZMB-00101-108, BIOS 2.0.7
12/08/2016
[ 1285.604429] task: ffff8817a2c89740 task.stack: ffffc9000e17c000
[ 1285.604438] RIP: 0010:nova_rebuild_dir_inode_tree+0x5fa/0x650
[ 1285.604439] RSP: 0018:ffffc9000e17fc30 EFLAGS: 00010286
[ 1285.604442] RAX: 0000000000000000 RBX: 0000000000000000 RCX:
0000000000000000
[ 1285.604443] RDX: 0000000000000001 RSI: 0000000000000002 RDI:
0000000000000246
[ 1285.604445] RBP: ffffc9000e17fe08 R08: 0000000000000000 R09:
0000000000000013
[ 1285.604446] R10: ffffc9000e17fe18 R11: 0000000001fe35d8 R12:
ffff8817a4b18918
[ 1285.604448] R13: ffff88180e073800 R14: 0000000000000000 R15:
ffff8803f6993180
[ 1285.604450] FS:  00007f8ab90d5e00(0000) GS:ffff881823280000(0000) knlGS:0000000000000000
[ 1285.604452] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[ 1285.604453] CR2: 00007f8ab83b4160 CR3: 00000017e0cdf000 CR4: 00000000000406e0
[ 1285.604455] Call Trace:
[ 1285.604468]  ? nova_append_dir_init_entries+0x554/0x6c0
[ 1285.604471]  ? inode_init_always+0x13c/0x1f0
[ 1285.604475]  ? insert_inode_locked+0xe9/0x1c0
[ 1285.604479]  nova_mkdir+0x16a/0x2f0
[ 1285.604483]  ? lookup_dcache+0x1d/0x60
[ 1285.604486]  vfs_mkdir+0x10f/0x1b0
[ 1285.604489]  SyS_mkdir+0x7a/0xf0
[ 1285.604494]  entry_SYSCALL_64_fastpath+0x1a/0xa5
[ 1285.604497] RIP: 0033:0x7f8ab83c08a7
[ 1285.604498] RSP: 002b:00007fffd0dd3af8 EFLAGS: 00000202 ORIG_RAX: 0000000000000053
[ 1285.604501] RAX: ffffffffffffffda RBX: 00007fffd0dd3e08 RCX: 00007f8ab83c08a7
[ 1285.604502] RDX: 0000000000000000 RSI: 00000000000001ff RDI: 00007fffd0dd5677
[ 1285.604504] RBP: 0000000000000003 R08: 00000000000001ff R09: 0000000000402af0
[ 1285.604505] R10: 00000000000001e6 R11: 0000000000000202 R12: 0000000000000000
[ 1285.604506] R13: 0000000000402b30 R14: 0000000000000000 R15: 0000000000000000
[ 1285.604509] Code: a6 81 48 8d 50 30 e8 87 7a dd ff 41 0f b6 4d 01
e9 ae fd ff ff 48 8b 95 28 fe ff ff 48 c7 c6 bf ce a6 81 4c 89 ef e8
06 4f 00 00 <0f> 0b 48 8b b5 28 fe ff ff 48 c7 c7 f8 cc a6 81 48 89
95 48 fe
[ 1285.604543] RIP: nova_rebuild_dir_inode_tree+0x5fa/0x650 RSP: ffffc9000e17fc30
[ 1285.604562] ---[ end trace 2ed8f3c1075a570e ]---
[ 1287.011803] Kernel panic - not syncing: Fatal exception
[ 1287.011887] Kernel Offset: disabled
[ 1287.653667] ---[ end Kernel panic - not syncing: Fatal exception
[ 1287.660587] sched: Unexpected reschedule of offline CPU#1!]

Signed-off-by: Yuanliang Wang <yuanliang.wyl@alibaba-inc.com>
  