### PR TITLE
fs,nova: fix build warning when ignore return value check of memcpy_mcsafe

### DIFF
--- a/fs/nova/perf.c
+++ b/fs/nova/perf.c
@@ -54,8 +54,7 @@ static int from_pmem_call(char *dst, char *src, size_t off, size_t size)
 {
 	/* pin dst address to cache most writes, if size fits */
 	/* src address should point to pmem */
-	memcpy_mcsafe(dst, src + off, size);
-	return 0;
+	return memcpy_mcsafe(dst, src + off, size);
 }
 
 static const memcpy_call_t from_pmem_calls[] = {


### PR DESCRIPTION

Function from_pmem_call of nova ignores the return value check
of memcpy_mcsafe which with __must_check in it, __must_check is
__attribute__((warn_unused_result)), so trigger the following
compiler warning

fs/nova/perf.c: In function ‘from_pmem_call’:
fs/nova/perf.c:57:2: warning: ignoring return value of ‘memcpy_mcsafe’,
declared with attribute warn_unused_result [-Wunused-result]
memcpy_mcsafe(dst, src + off, size);
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Yuanliang Wang <yuanliang.wyl@alibaba-inc.com>