### PR TITLE
fs,nova: favor huge page mapping automatically

### DIFF
--- a/fs/nova/file.c
+++ b/fs/nova/file.c
@@ -990,6 +990,7 @@ const struct file_operations nova_wrap_file_operations = {
 	.read_iter		= nova_wrap_rw_iter,
 	.write_iter		= nova_wrap_rw_iter,
 	.mmap			= nova_dax_file_mmap,
+	.get_unmapped_area = thp_get_unmapped_area,
 	.open			= nova_open,
 	.fsync			= nova_fsync,
 	.flush			= nova_flush,


### PR DESCRIPTION
In case of creating mapping with size fit into huge page,
2M for example, use thp_get_unmapped_area to get start
address aligned in huge page size, which in turn will
huge page mapping in case of page fault.

Before
------
[ 2841.949504] nova: [nova_dax_file_mmap:901] inode 208, MMAP 4KPAGE vm_start(0x7f661d141000), vm_end(0x7f661d541000), vm pgoff 0, 1024 blocks, vm_flags(0x300000fb), vm_page_prot(0x8000000000000027)

After
-----
[13010.829945] nova: [nova_dax_file_mmap:901] inode 208, MMAP 4KPAGE vm_start(0x7f8699c00000), vm_end(0x7f869a000000), vm pgoff 0, 1024 blocks, vm_flags(0x300000fb), vm_page_prot(0x8000000000000027)

Signed-off-by: Fan Du <fan.du@intel.com>