### PR TITLE
fs,nova: Allow huge block(2M) allocation

### DIFF
--- a/fs/nova/balloc.c
+++ b/fs/nova/balloc.c
@@ -569,6 +569,11 @@ static int not_enough_blocks(struct free_list *free_list,
 	return 0;
 }
 
+struct nova_range_node *nova_alloc_blocknode_atomic(struct super_block *sb)
+{
+	return nova_alloc_range_node_atomic(sb);
+}
+
 /* Return how many blocks allocated */
 static long nova_alloc_blocks_in_free_list(struct super_block *sb,
 	struct free_list *free_list, unsigned short btype,

--- a/fs/nova/super.c
+++ b/fs/nova/super.c
@@ -983,6 +983,15 @@ void nova_free_snapshot_info(struct snapshot_info *info)
 	kmem_cache_free(nova_snapshot_info_cachep, info);
 }
 
+struct nova_range_node *nova_alloc_range_node_atomic(struct super_block *sb)
+{
+	struct nova_range_node *p;
+
+	p = (struct nova_range_node *)
+		kmem_cache_zalloc(nova_range_node_cachep, GFP_ATOMIC);
+	return p;
+}
+
 struct nova_range_node *nova_alloc_range_node(struct super_block *sb)
 {
 	struct nova_range_node *p;

--- a/fs/nova/super.h
+++ b/fs/nova/super.h
@@ -208,6 +208,7 @@ extern int nova_statfs(struct dentry *d, struct kstatfs *buf);
 extern int nova_remount(struct super_block *sb, int *flags, char *data);
 void *nova_ioremap(struct super_block *sb, phys_addr_t phys_addr,
 	ssize_t size);
+extern struct nova_range_node *nova_alloc_range_node_atomic(struct super_block *sb);
 extern struct nova_range_node *nova_alloc_range_node(struct super_block *sb);
 extern void nova_free_range_node(struct nova_range_node *node);
 extern void nova_update_super_crc(struct super_block *sb);


### PR DESCRIPTION
This is a follow-up of https://github.com/NVSL/linux-nova/pull/64.

To leverage huge page mapping when doing mmap, both virtual
address range as well as physical block is required to be
aligned at huge page boundary.

This patch aims to support 2M allocation first as 1G huge
page mapping is not yet supported in fs/dax level.

It's straight forward to try huge allocation first, fall
back to un-aligned allocation if unlucky.

Note:
We don't need to hard code NOVA_DEFAULT_BLOCK_TYPE to 2M
when initiates inode structure, the page fault handler itself
will try huge mapping, and then pte mapping if huge mapping
is not welcomed.

Test fsdax trace log:
        fs-write-12957 [063] ....  3780.549974: dax_pmd_fault: dev 259:0 ino 0xd0 shared WRITE|ALLOW_RETRY|KILLABLE|USER address 0x7fa7bf800000 vm_start 0x7fa7bf800000 vm_end 0x7fa7bfc00000 pgoff 0x0 max_pgoff 0x3ff
        fs-write-12957 [063] ....  3780.553204: dax_pmd_insert_mapping: dev 259:0 ino 0xd0 shared write address 0x7fa7bf800000 length 0x200000 pfn 0x13722600 DEV|MAP radix_entry 0x11ec8000e
        fs-write-12957 [063] ....  3780.553212: dax_pmd_fault_done: dev 259:0 ino 0xd0 shared WRITE|ALLOW_RETRY|KILLABLE|USER address 0x7fa7bf800000 vm_start 0x7fa7bf800000 vm_end 0x7fa7bfc00000 pgoff 0x0 max_pgoff 0x3ff NOPAGE

Signed-off-by: Fan Du <fan.du@intel.com>