### PR TITLE
Fix mkdir crash consistency bugs

### DIFF
--- a/fs/nova/dir.c
+++ b/fs/nova/dir.c
@@ -240,6 +240,7 @@ int nova_append_dir_init_entries(struct super_block *sb,
 
 	nova_update_tail(pi, new_block + length);
 
+	nova_flush_buffer(&(pi->log_head), CACHELINE_SIZE, 0);
 	nova_memlock_inode(sb, pi);
 
 	if (metadata_csum == 0)

--- a/fs/nova/log.c
+++ b/fs/nova/log.c
@@ -1410,6 +1410,7 @@ int nova_free_inode_log(struct super_block *sb, struct nova_inode *pi,
 						sizeof(struct nova_inode));
 			}
 		}
+		nova_flush_buffer(pi, sizeof(struct nova_inode), 0); 
 		nova_memlock_inode(sb, pi);
 	}
 

--- a/fs/nova/namei.c
+++ b/fs/nova/namei.c
@@ -99,6 +99,7 @@ static void nova_lite_transaction_for_new_inode(struct super_block *sb,
 	nova_update_inode(sb, dir, pidir, update, 0);
 
 	pi->valid = 1;
+	nova_flush_buffer(&(pi->valid), CACHELINE_SIZE, 0);
 	nova_update_inode_checksum(pi);
 	PERSISTENT_BARRIER();
 


### PR DESCRIPTION
This PR adds calls to `nova_flush_buffer()` to `nova_free_inode_log()` in log.c, `nova_append_dir_init_entries()` in dir.c, and `nova_lite_transaction_for_new_inode()` in namei.c to address the crash consistency bugs described in issue #91. 