### PR TITLE
Fix #94 bug

### DIFF
--- a/fs/nova/bbuild.c
+++ b/fs/nova/bbuild.c
@@ -1046,8 +1046,14 @@ again:
 	curr_p = pi->log_head;
 	nova_dbg_verbose("Log head 0x%llx, tail 0x%llx\n",
 				curr_p, pi->log_tail);
-	if (curr_p == 0 && pi->log_tail == 0)
+	if (curr_p == 0 || pi->log_tail == 0) {
+		nova_warn("NULL log pointer(s) in file inode %llu\n", ino);
+		pi->log_head = 0;
+		pi->log_tail = 0;
+		nova_flush_buffer(pi, sizeof(struct nova_inode), 1);
 		return 0;
+	}
+
 
 	if (base == 0) {
 		BUG_ON(curr_p & (PAGE_SIZE - 1));

--- a/fs/nova/inode.h
+++ b/fs/nova/inode.h
@@ -178,12 +178,13 @@ static inline int nova_update_inode_checksum(struct nova_inode *pi)
 	u32 crc = 0;
 
 	if (metadata_csum == 0)
-		return 0;
+		goto persist;
 
 	crc = nova_crc32c(~0, (__u8 *)pi,
 			(sizeof(struct nova_inode) - sizeof(__le32)));
 
 	pi->csum = crc;
+persist:
 	nova_flush_buffer(pi, sizeof(struct nova_inode), 1);
 	return 0;
 }

--- a/fs/nova/log.c
+++ b/fs/nova/log.c
@@ -1410,7 +1410,6 @@ int nova_free_inode_log(struct super_block *sb, struct nova_inode *pi,
 						sizeof(struct nova_inode));
 			}
 		}
-		nova_flush_buffer(pi, sizeof(struct nova_inode), 0); 
 		nova_memlock_inode(sb, pi);
 	}
 

--- a/fs/nova/namei.c
+++ b/fs/nova/namei.c
@@ -99,7 +99,6 @@ static void nova_lite_transaction_for_new_inode(struct super_block *sb,
 	nova_update_inode(sb, dir, pidir, update, 0);
 
 	pi->valid = 1;
-	nova_flush_buffer(&(pi->valid), CACHELINE_SIZE, 0);
 	nova_update_inode_checksum(pi);
 	PERSISTENT_BARRIER();
 

--- a/fs/nova/rebuild.c
+++ b/fs/nova/rebuild.c
@@ -409,8 +409,15 @@ static int nova_rebuild_file_inode_tree(struct super_block *sb,
 		goto out;
 
 	curr_p = sih->log_head;
-	if (curr_p == 0 && sih->log_tail == 0)
+	// if (curr_p == 0 && sih->log_tail == 0)
+	// 	goto out;
+	if (curr_p == 0 || sih->log_tail == 0) {
+		nova_warn("NULL log pointer(s) in file inode %llu\n", ino);
+		pi->log_head = 0;
+		pi->log_tail = 0;
+		nova_flush_buffer(pi, sizeof(struct nova_inode), 1);
 		goto out;
+	}
 
 	entryc = (metadata_csum == 0) ? NULL : entry_copy;
 


### PR DESCRIPTION
This PR fixes the crash consistency bug described in #94 and ensures that `nova_update_inode_checksum()` always calls `nova_flush_buffer()`. 