### PR TITLE
Fix wprotect by moving irq flags into stack.

### DIFF
--- a/fs/nova/balloc.c
+++ b/fs/nova/balloc.c
@@ -876,6 +876,7 @@ static int nova_new_blocks(struct super_block *sb, unsigned long *blocknr,
 	unsigned long new_blocknr = 0;
 	long ret_blocks = 0;
 	int retried = 0;
+	unsigned long irq_flags = 0;
 	INIT_TIMING(alloc_time);
 
 	num_blocks = num * nova_get_numblocks(btype);
@@ -934,9 +935,9 @@ alloc:
 	if (zero) {
 		bp = nova_get_block(sb, nova_get_block_off(sb,
 						new_blocknr, btype));
-		nova_memunlock_range(sb, bp, PAGE_SIZE * ret_blocks);
+		nova_memunlock_range(sb, bp, PAGE_SIZE * ret_blocks, &irq_flags);
 		memset_nt(bp, 0, PAGE_SIZE * ret_blocks);
-		nova_memlock_range(sb, bp, PAGE_SIZE * ret_blocks);
+		nova_memlock_range(sb, bp, PAGE_SIZE * ret_blocks, &irq_flags);
 	}
 	*blocknr = new_blocknr;
 

--- a/fs/nova/bbuild.c
+++ b/fs/nova/bbuild.c
@@ -365,6 +365,7 @@ static u64 nova_append_range_node_entry(struct super_block *sb,
 	u64 curr_p;
 	size_t size = sizeof(struct nova_range_node_lowhigh);
 	struct nova_range_node_lowhigh *entry;
+	unsigned long irq_flags = 0;
 
 	curr_p = tail;
 
@@ -383,12 +384,12 @@ static u64 nova_append_range_node_entry(struct super_block *sb,
 		curr_p = next_log_page(sb, curr_p);
 
 	entry = (struct nova_range_node_lowhigh *)nova_get_block(sb, curr_p);
-	nova_memunlock_range(sb, entry, size);
+	nova_memunlock_range(sb, entry, size, &irq_flags);
 	entry->range_low = cpu_to_le64(curr->range_low);
 	if (cpuid)
 		entry->range_low |= cpu_to_le64(cpuid << 56);
 	entry->range_high = cpu_to_le64(curr->range_high);
-	nova_memlock_range(sb, entry, size);
+	nova_memlock_range(sb, entry, size, &irq_flags);
 	nova_dbgv("append entry block low 0x%lx, high 0x%lx\n",
 			curr->range_low, curr->range_high);
 
@@ -443,6 +444,7 @@ void nova_save_inode_list_to_log(struct super_block *sb)
 	u64 temp_tail;
 	u64 new_block;
 	int allocated;
+	unsigned long irq_flags = 0;
 
 	sih.ino = NOVA_INODELIST_INO;
 	sih.i_blk_type = NOVA_DEFAULT_BLOCK_TYPE;
@@ -471,12 +473,12 @@ void nova_save_inode_list_to_log(struct super_block *sb)
 				&inode_map->inode_inuse_tree, temp_tail, i);
 	}
 
-	nova_memunlock_inode(sb, pi);
+	nova_memunlock_inode(sb, pi, &irq_flags);
 	pi->alter_log_head = pi->alter_log_tail = 0;
 	pi->log_head = new_block;
 	nova_update_tail(pi, temp_tail);
 	nova_flush_buffer(&pi->log_head, CACHELINE_SIZE, 0);
-	nova_memlock_inode(sb, pi);
+	nova_memlock_inode(sb, pi, &irq_flags);
 
 	nova_dbg("%s: %lu inode nodes, pi head 0x%llx, tail 0x%llx\n",
 		__func__, num_nodes, pi->log_head, pi->log_tail);
@@ -494,6 +496,7 @@ void nova_save_blocknode_mappings_to_log(struct super_block *sb)
 	u64 new_block = 0;
 	u64 temp_tail;
 	int i;
+	unsigned long irq_flags = 0;
 
 	sih.ino = NOVA_BLOCKNODE_INO;
 	sih.i_blk_type = NOVA_DEFAULT_BLOCK_TYPE;
@@ -522,12 +525,12 @@ void nova_save_blocknode_mappings_to_log(struct super_block *sb)
 		temp_tail = nova_save_free_list_blocknodes(sb, i, temp_tail);
 
 	/* Finally update log head and tail */
-	nova_memunlock_inode(sb, pi);
+	nova_memunlock_inode(sb, pi, &irq_flags);
 	pi->alter_log_head = pi->alter_log_tail = 0;
 	pi->log_head = new_block;
 	nova_update_tail(pi, temp_tail);
 	nova_flush_buffer(&pi->log_head, CACHELINE_SIZE, 0);
-	nova_memlock_inode(sb, pi);
+	nova_memlock_inode(sb, pi, &irq_flags);
 
 	nova_dbg("%s: %lu blocknodes, %lu log pages, pi head 0x%llx, tail 0x%llx\n",
 		  __func__, num_blocknode, num_pages,

--- a/fs/nova/ioctl.c
+++ b/fs/nova/ioctl.c
@@ -32,6 +32,7 @@ long nova_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	struct nova_inode_update update;
 	unsigned int flags;
 	int ret;
+	unsigned long irq_flags = 0;
 
 	pi = nova_get_inode(sb, inode);
 	if (!pi)
@@ -86,9 +87,9 @@ long nova_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		ret = nova_append_link_change_entry(sb, pi, inode,
 					&update, &old_linkc, epoch_id);
 		if (!ret) {
-			nova_memunlock_inode(sb, pi);
+			nova_memunlock_inode(sb, pi, &irq_flags);
 			nova_update_inode(sb, inode, pi, &update, 1);
-			nova_memlock_inode(sb, pi);
+			nova_memlock_inode(sb, pi, &irq_flags);
 			nova_invalidate_link_change_entry(sb, old_linkc);
 		}
 		sih->trans_id++;
@@ -125,9 +126,9 @@ flags_out:
 		ret = nova_append_link_change_entry(sb, pi, inode,
 					&update, &old_linkc, epoch_id);
 		if (!ret) {
-			nova_memunlock_inode(sb, pi);
+			nova_memunlock_inode(sb, pi, &irq_flags);
 			nova_update_inode(sb, inode, pi, &update, 1);
-			nova_memlock_inode(sb, pi);
+			nova_memlock_inode(sb, pi, &irq_flags);
 			nova_invalidate_link_change_entry(sb, old_linkc);
 		}
 		sih->trans_id++;

--- a/fs/nova/log.c
+++ b/fs/nova/log.c
@@ -79,12 +79,13 @@ static int nova_invalidate_reassign_logentry(struct super_block *sb,
 	void *entry, enum nova_entry_type type, int reassign,
 	unsigned int num_free)
 {
-	nova_memunlock_range(sb, entry, CACHELINE_SIZE);
+	unsigned long irq_flags = 0;
+	nova_memunlock_range(sb, entry, CACHELINE_SIZE, &irq_flags);
 
 	nova_execute_invalidate_reassign_logentry(sb, entry, type,
 						reassign, num_free);
 	nova_update_alter_entry(sb, entry);
-	nova_memlock_range(sb, entry, CACHELINE_SIZE);
+	nova_memlock_range(sb, entry, CACHELINE_SIZE, &irq_flags);
 
 	return 0;
 }
@@ -202,6 +203,7 @@ void nova_clear_last_page_tail(struct super_block *sb,
 	unsigned long pgoff, length;
 	u64 nvmm;
 	char *nvmm_addr;
+	unsigned long irq_flags = 0;
 
 	if (offset == 0 || newsize > inode->i_size)
 		return;
@@ -214,9 +216,9 @@ void nova_clear_last_page_tail(struct super_block *sb,
 		return;
 
 	nvmm_addr = (char *)nova_get_block(sb, nvmm);
-	nova_memunlock_range(sb, nvmm_addr + offset, length);
+	nova_memunlock_range(sb, nvmm_addr + offset, length, &irq_flags);
 	memcpy_to_pmem_nocache(nvmm_addr + offset, sbi->zeroed_page, length);
-	nova_memlock_range(sb, nvmm_addr + offset, length);
+	nova_memlock_range(sb, nvmm_addr + offset, length, &irq_flags);
 
 	if (data_csum > 0)
 		nova_update_truncated_block_csum(sb, inode, newsize);
@@ -405,6 +407,7 @@ static int nova_append_log_entry(struct super_block *sb,
 	u64 curr_p, alter_curr_p;
 	size_t size;
 	int extended = 0;
+	unsigned long irq_flags = 0;
 
 	if (type == DIR_LOG)
 		size = entry_info->file_size;
@@ -424,11 +427,11 @@ static int nova_append_log_entry(struct super_block *sb,
 
 	entry = nova_get_block(sb, curr_p);
 	/* inode is already updated with attr */
-	nova_memunlock_range(sb, entry, size);
+	nova_memunlock_range(sb, entry, size, &irq_flags);
 	memset(entry, 0, size);
 	nova_update_log_entry(sb, inode, entry, entry_info);
 	nova_inc_page_num_entries(sb, curr_p);
-	nova_memlock_range(sb, entry, size);
+	nova_memlock_range(sb, entry, size, &irq_flags);
 	update->curr_entry = curr_p;
 	update->tail = curr_p + size;
 
@@ -439,10 +442,10 @@ static int nova_append_log_entry(struct super_block *sb,
 			return -ENOSPC;
 
 		alter_entry = nova_get_block(sb, alter_curr_p);
-		nova_memunlock_range(sb, alter_entry, size);
+		nova_memunlock_range(sb, alter_entry, size, &irq_flags);
 		memset(alter_entry, 0, size);
 		nova_update_log_entry(sb, inode, alter_entry, entry_info);
-		nova_memlock_range(sb, alter_entry, size);
+		nova_memlock_range(sb, alter_entry, size, &irq_flags);
 
 		update->alter_entry = alter_curr_p;
 		update->alter_tail = alter_curr_p + size;
@@ -461,30 +464,31 @@ int nova_inplace_update_log_entry(struct super_block *sb,
 	u64 journal_tail;
 	size_t size;
 	int cpu;
+	unsigned long irq_flags = 0;
 	INIT_TIMING(update_time);
 
 	NOVA_START_TIMING(update_entry_t, update_time);
 	size = nova_get_log_entry_size(sb, type);
 
 	if (metadata_csum) {
-		nova_memunlock_range(sb, entry, size);
+		nova_memunlock_range(sb, entry, size, &irq_flags);
 		nova_update_log_entry(sb, inode, entry, entry_info);
 		// Also update the alter inode log entry.
 		nova_update_alter_entry(sb, entry);
-		nova_memlock_range(sb, entry, size);
+		nova_memlock_range(sb, entry, size, &irq_flags);
 		goto out;
 	}
 
 	cpu = nova_get_cpuid(sb);
 	spin_lock(&sbi->journal_locks[cpu]);
-	nova_memunlock_journal(sb);
+	nova_memunlock_journal(sb, &irq_flags);
 	journal_tail = nova_create_logentry_transaction(sb, entry, type, cpu);
 	nova_update_log_entry(sb, inode, entry, entry_info);
 
 	PERSISTENT_BARRIER();
 
 	nova_commit_lite_transaction(sb, journal_tail, cpu);
-	nova_memlock_journal(sb);
+	nova_memlock_journal(sb, &irq_flags);
 	spin_unlock(&sbi->journal_locks[cpu]);
 out:
 	NOVA_END_TIMING(update_entry_t, update_time);
@@ -628,6 +632,7 @@ int nova_handle_setattr_operation(struct super_block *sb, struct inode *inode,
 	struct nova_inode_update update;
 	u64 last_setattr = 0;
 	int ret;
+	unsigned long irq_flags = 0;
 
 	if (ia_valid & ATTR_MODE)
 		sih->i_mode = inode->i_mode;
@@ -656,9 +661,9 @@ int nova_handle_setattr_operation(struct super_block *sb, struct inode *inode,
 			return ret;
 		}
 
-		nova_memunlock_inode(sb, pi);
+		nova_memunlock_inode(sb, pi, &irq_flags);
 		nova_update_inode(sb, inode, pi, &update, 1);
-		nova_memlock_inode(sb, pi);
+		nova_memlock_inode(sb, pi, &irq_flags);
 	}
 
 	/* Invalidate old setattr entry */
@@ -861,11 +866,12 @@ int nova_inplace_update_write_entry(struct super_block *sb,
 int nova_set_write_entry_updating(struct super_block *sb,
 	struct nova_file_write_entry *entry, int set)
 {
-	nova_memunlock_range(sb, entry, sizeof(*entry));
+	unsigned long irq_flags = 0;
+	nova_memunlock_range(sb, entry, sizeof(*entry), &irq_flags);
 	entry->updating = set ? 1 : 0;
 	nova_update_entry_csum(entry);
 	nova_update_alter_entry(sb, entry);
-	nova_memlock_range(sb, entry, sizeof(*entry));
+	nova_memlock_range(sb, entry, sizeof(*entry), &irq_flags);
 
 	return 0;
 }
@@ -1048,6 +1054,7 @@ static int nova_coalesce_log_pages(struct super_block *sb,
 	u64 curr_block, next_page;
 	struct nova_inode_log_page *curr_page;
 	int i;
+	unsigned long irq_flags = 0;
 
 	if (prev_blocknr) {
 		/* Link prev block and newly allocated head block */
@@ -1057,9 +1064,9 @@ static int nova_coalesce_log_pages(struct super_block *sb,
 				nova_get_block(sb, curr_block);
 		next_page = nova_get_block_off(sb, first_blocknr,
 				NOVA_BLOCK_TYPE_4K);
-		nova_memunlock_block(sb, curr_page);
+		nova_memunlock_block(sb, curr_page, &irq_flags);
 		nova_set_next_page_address(sb, curr_page, next_page, 0);
-		nova_memlock_block(sb, curr_page);
+		nova_memlock_block(sb, curr_page, &irq_flags);
 	}
 
 	next_blocknr = first_blocknr + 1;
@@ -1070,21 +1077,21 @@ static int nova_coalesce_log_pages(struct super_block *sb,
 	for (i = 0; i < num_pages - 1; i++) {
 		next_page = nova_get_block_off(sb, next_blocknr,
 				NOVA_BLOCK_TYPE_4K);
-		nova_memunlock_block(sb, curr_page);
+		nova_memunlock_block(sb, curr_page, &irq_flags);
 		nova_set_page_num_entries(sb, curr_page, 0, 0);
 		nova_set_page_invalid_entries(sb, curr_page, 0, 0);
 		nova_set_next_page_address(sb, curr_page, next_page, 0);
-		nova_memlock_block(sb, curr_page);
+		nova_memlock_block(sb, curr_page, &irq_flags);
 		curr_page++;
 		next_blocknr++;
 	}
 
 	/* Last page */
-	nova_memunlock_block(sb, curr_page);
+	nova_memunlock_block(sb, curr_page, &irq_flags);
 	nova_set_page_num_entries(sb, curr_page, 0, 0);
 	nova_set_page_invalid_entries(sb, curr_page, 0, 0);
 	nova_set_next_page_address(sb, curr_page, 0, 1);
-	nova_memlock_block(sb, curr_page);
+	nova_memlock_block(sb, curr_page, &irq_flags);
 	return 0;
 }
 
@@ -1150,6 +1157,7 @@ static int nova_initialize_inode_log(struct super_block *sb,
 {
 	u64 new_block;
 	int allocated;
+	unsigned long irq_flags = 0;
 
 	allocated = nova_allocate_inode_log_pages(sb, sih,
 					1, &new_block, ANY_CPU,
@@ -1160,7 +1168,7 @@ static int nova_initialize_inode_log(struct super_block *sb,
 		return -ENOSPC;
 	}
 
-	nova_memunlock_inode(sb, pi);
+	nova_memunlock_inode(sb, pi, &irq_flags);
 	if (log_id == MAIN_LOG) {
 		pi->log_tail = new_block;
 		nova_flush_buffer(&pi->log_tail, CACHELINE_SIZE, 0);
@@ -1177,7 +1185,7 @@ static int nova_initialize_inode_log(struct super_block *sb,
 		nova_flush_buffer(&pi->alter_log_head, CACHELINE_SIZE, 1);
 	}
 	nova_update_inode_checksum(pi);
-	nova_memlock_inode(sb, pi);
+	nova_memlock_inode(sb, pi, &irq_flags);
 
 	return 0;
 }
@@ -1193,6 +1201,7 @@ static u64 nova_extend_inode_log(struct super_block *sb, struct nova_inode *pi,
 	int allocated;
 	unsigned long num_pages;
 	int ret;
+	unsigned long irq_flags = 0;
 
 	nova_dbgv("%s: inode %lu, curr 0x%llx\n", __func__, sih->ino, curr_p);
 
@@ -1206,10 +1215,10 @@ static u64 nova_extend_inode_log(struct super_block *sb, struct nova_inode *pi,
 			if (ret)
 				return 0;
 
-			nova_memunlock_inode(sb, pi);
+			nova_memunlock_inode(sb, pi, &irq_flags);
 			nova_update_alter_pages(sb, pi, sih->log_head,
 							sih->alter_log_head);
-			nova_memlock_inode(sb, pi);
+			nova_memlock_inode(sb, pi, &irq_flags);
 		}
 
 		return sih->log_head;
@@ -1243,9 +1252,9 @@ static u64 nova_extend_inode_log(struct super_block *sb, struct nova_inode *pi,
 			return 0;
 		}
 
-		nova_memunlock_inode(sb, pi);
+		nova_memunlock_inode(sb, pi, &irq_flags);
 		nova_update_alter_pages(sb, pi, new_block, alter_new_block);
-		nova_memlock_inode(sb, pi);
+		nova_memlock_inode(sb, pi, &irq_flags);
 	}
 
 
@@ -1268,6 +1277,7 @@ static u64 nova_append_one_log_page(struct super_block *sb,
 	u64 new_block;
 	u64 curr_block;
 	int allocated;
+	unsigned long irq_flags = 0;
 
 	allocated = nova_allocate_inode_log_pages(sb, sih, 1, &new_block,
 							ANY_CPU, 0);
@@ -1284,9 +1294,9 @@ static u64 nova_append_one_log_page(struct super_block *sb,
 		curr_block = BLOCK_OFF(curr_p);
 		curr_page = (struct nova_inode_log_page *)
 				nova_get_block(sb, curr_block);
-		nova_memunlock_block(sb, curr_page);
+		nova_memunlock_block(sb, curr_page, &irq_flags);
 		nova_set_next_page_address(sb, curr_page, new_block, 1);
-		nova_memlock_block(sb, curr_page);
+		nova_memlock_block(sb, curr_page, &irq_flags);
 	}
 
 	return curr_p;
@@ -1297,6 +1307,7 @@ u64 nova_get_append_head(struct super_block *sb, struct nova_inode *pi,
 	int thorough_gc, int *extended)
 {
 	u64 curr_p;
+	unsigned long irq_flags = 0;
 
 	if (tail)
 		curr_p = tail;
@@ -1308,9 +1319,9 @@ u64 nova_get_append_head(struct super_block *sb, struct nova_inode *pi,
 	if (curr_p == 0 || (is_last_entry(curr_p, size) &&
 				next_log_page(sb, curr_p) == 0)) {
 		if (is_last_entry(curr_p, size)) {
-			nova_memunlock_block(sb, nova_get_block(sb, curr_p));
+			nova_memunlock_block(sb, nova_get_block(sb, curr_p), &irq_flags);
 			nova_set_next_page_flag(sb, curr_p);
-			nova_memlock_block(sb, nova_get_block(sb, curr_p));
+			nova_memlock_block(sb, nova_get_block(sb, curr_p), &irq_flags);
 		}
 
 		/* Alternate log should not go here */
@@ -1330,9 +1341,9 @@ u64 nova_get_append_head(struct super_block *sb, struct nova_inode *pi,
 	}
 
 	if (is_last_entry(curr_p, size)) {
-		nova_memunlock_block(sb, nova_get_block(sb, curr_p));
+		nova_memunlock_block(sb, nova_get_block(sb, curr_p), &irq_flags);
 		nova_set_next_page_flag(sb, curr_p);
-		nova_memlock_block(sb, nova_get_block(sb, curr_p));
+		nova_memlock_block(sb, nova_get_block(sb, curr_p), &irq_flags);
 		curr_p = next_log_page(sb, curr_p);
 	}
 
@@ -1389,6 +1400,7 @@ int nova_free_inode_log(struct super_block *sb, struct nova_inode *pi,
 {
 	struct nova_inode *alter_pi;
 	int freed = 0;
+	unsigned long irq_flags = 0;
 	INIT_TIMING(free_time);
 
 	if (sih->log_head == 0 || sih->log_tail == 0)
@@ -1398,7 +1410,7 @@ int nova_free_inode_log(struct super_block *sb, struct nova_inode *pi,
 
 	/* The inode is invalid now, no need to fence */
 	if (pi) {
-		nova_memunlock_inode(sb, pi);
+		nova_memunlock_inode(sb, pi, &irq_flags);
 		pi->log_head = pi->log_tail = 0;
 		pi->alter_log_head = pi->alter_log_tail = 0;
 		nova_update_inode_checksum(pi);
@@ -1410,7 +1422,7 @@ int nova_free_inode_log(struct super_block *sb, struct nova_inode *pi,
 						sizeof(struct nova_inode));
 			}
 		}
-		nova_memlock_inode(sb, pi);
+		nova_memlock_inode(sb, pi, &irq_flags);
 	}
 
 	freed = nova_free_contiguous_log_blocks(sb, sih, sih->log_head);

--- a/fs/nova/mprotect.c
+++ b/fs/nova/mprotect.c
@@ -25,53 +25,6 @@
 #include "nova.h"
 #include "inode.h"
 
-static inline void wprotect_disable(void)
-{
-	unsigned long cr0_val;
-
-	cr0_val = read_cr0();
-	cr0_val &= (~X86_CR0_WP);
-	write_cr0(cr0_val);
-}
-
-static inline void wprotect_enable(void)
-{
-	unsigned long cr0_val;
-
-	cr0_val = read_cr0();
-	cr0_val |= X86_CR0_WP;
-	write_cr0(cr0_val);
-}
-
-/* FIXME: Assumes that we are always called in the right order.
- * nova_writeable(vaddr, size, 1);
- * nova_writeable(vaddr, size, 0);
- */
-int nova_writeable(void *vaddr, unsigned long size, int rw)
-{
-	static unsigned long flags;
-	INIT_TIMING(wprotect_time);
-
-	NOVA_START_TIMING(wprotect_t, wprotect_time);
-	if (rw) {
-		local_irq_save(flags);
-		wprotect_disable();
-	} else {
-		wprotect_enable();
-		local_irq_restore(flags);
-	}
-	NOVA_END_TIMING(wprotect_t, wprotect_time);
-	return 0;
-}
-
-int nova_dax_mem_protect(struct super_block *sb, void *vaddr,
-			  unsigned long size, int rw)
-{
-	if (!nova_is_wprotected(sb))
-		return 0;
-	return nova_writeable(vaddr, size, rw);
-}
-
 int nova_get_vma_overlap_range(struct super_block *sb,
 	struct nova_inode_info_header *sih, struct vm_area_struct *vma,
 	unsigned long entry_pgoff, unsigned long entry_pages,
@@ -315,6 +268,7 @@ int nova_mmap_to_new_blocks(struct vm_area_struct *vma,
 	u32 time;
 	INIT_TIMING(mmap_cow_time);
 	int ret = 0;
+	unsigned long irq_flags = 0;
 
 	NOVA_START_TIMING(mmap_cow_t, mmap_cow_time);
 
@@ -418,10 +372,10 @@ int nova_mmap_to_new_blocks(struct vm_area_struct *vma,
 
 		/* Now copy from user buf */
 		NOVA_START_TIMING(memcpy_w_wb_t, memcpy_time);
-		nova_memunlock_range(sb, to_kmem, bytes);
+		nova_memunlock_range(sb, to_kmem, bytes, &irq_flags);
 		copied = bytes - memcpy_to_pmem_nocache(to_kmem, from_kmem,
 							bytes);
-		nova_memlock_range(sb, to_kmem, bytes);
+		nova_memlock_range(sb, to_kmem, bytes, &irq_flags);
 		NOVA_END_TIMING(memcpy_w_wb_t, memcpy_time);
 
 		if (copied == bytes) {
@@ -455,9 +409,9 @@ int nova_mmap_to_new_blocks(struct vm_area_struct *vma,
 	if (begin_tail == 0)
 		goto out;
 
-	nova_memunlock_inode(sb, pi);
+	nova_memunlock_inode(sb, pi, &irq_flags);
 	nova_update_inode(sb, inode, pi, &update, 1);
-	nova_memlock_inode(sb, pi);
+	nova_memlock_inode(sb, pi, &irq_flags);
 
 	/* Update file tree */
 	ret = nova_reassign_file_tree(sb, sih, begin_tail);

--- a/fs/nova/mprotect.h
+++ b/fs/nova/mprotect.h
@@ -46,7 +46,44 @@ static inline int nova_range_check(struct super_block *sb, void *p,
 	return 0;
 }
 
-extern int nova_writeable(void *vaddr, unsigned long size, int rw);
+static inline void wprotect_disable(void)
+{
+	unsigned long cr0_val;
+
+	cr0_val = read_cr0();
+	cr0_val &= (~X86_CR0_WP);
+	write_cr0(cr0_val);
+}
+
+static inline void wprotect_enable(void)
+{
+	unsigned long cr0_val;
+
+	cr0_val = read_cr0();
+	cr0_val |= X86_CR0_WP;
+	write_cr0(cr0_val);
+}
+
+/* FIXME: Assumes that we are always called in the right order.
+ * nova_writeable(vaddr, size, 1);
+ * nova_writeable(vaddr, size, 0);
+ */
+static inline int
+nova_writeable(void *vaddr, unsigned long size, int rw, unsigned long *flags)
+{
+	INIT_TIMING(wprotect_time);
+
+	NOVA_START_TIMING(wprotect_t, wprotect_time);
+	if (rw) {
+		local_irq_save(*flags);
+		wprotect_disable();
+	} else {
+		wprotect_enable();
+		local_irq_restore(*flags);
+	}
+	NOVA_END_TIMING(wprotect_t, wprotect_time);
+	return 0;
+}
 
 static inline int nova_is_protected(struct super_block *sb)
 {
@@ -64,7 +101,7 @@ static inline int nova_is_wprotected(struct super_block *sb)
 }
 
 static inline void
-__nova_memunlock_range(void *p, unsigned long len)
+__nova_memunlock_range(void *p, unsigned long len, unsigned long *flags)
 {
 	/*
 	 * NOTE: Ideally we should lock all the kernel to be memory safe
@@ -73,69 +110,69 @@ __nova_memunlock_range(void *p, unsigned long len)
 	 * the operations at fs level. We can't disable the interrupts
 	 * because we could have a deadlock in this path.
 	 */
-	nova_writeable(p, len, 1);
+	nova_writeable(p, len, 1, flags);
 }
 
 static inline void
-__nova_memlock_range(void *p, unsigned long len)
+__nova_memlock_range(void *p, unsigned long len, unsigned long *flags)
 {
-	nova_writeable(p, len, 0);
+	nova_writeable(p, len, 0, flags);
 }
 
 static inline void nova_memunlock_range(struct super_block *sb, void *p,
-					 unsigned long len)
+					 unsigned long len, unsigned long *flags)
 {
 	if (nova_range_check(sb, p, len))
 		return;
 
 	if (nova_is_protected(sb))
-		__nova_memunlock_range(p, len);
+		__nova_memunlock_range(p, len, flags);
 }
 
 static inline void nova_memlock_range(struct super_block *sb, void *p,
-				       unsigned long len)
+				       unsigned long len, unsigned long *flags)
 {
 	if (nova_is_protected(sb))
-		__nova_memlock_range(p, len);
+		__nova_memlock_range(p, len, flags);
 }
 
-static inline void nova_memunlock_super(struct super_block *sb)
+static inline void nova_memunlock_super(struct super_block *sb, unsigned long *flags)
 {
 	struct nova_super_block *ps = nova_get_super(sb);
 
 	if (nova_is_protected(sb))
-		__nova_memunlock_range(ps, NOVA_SB_SIZE);
+		__nova_memunlock_range(ps, NOVA_SB_SIZE, flags);
 }
 
-static inline void nova_memlock_super(struct super_block *sb)
+static inline void nova_memlock_super(struct super_block *sb, unsigned long *flags)
 {
 	struct nova_super_block *ps = nova_get_super(sb);
 
 	if (nova_is_protected(sb))
-		__nova_memlock_range(ps, NOVA_SB_SIZE);
+		__nova_memlock_range(ps, NOVA_SB_SIZE, flags);
 }
 
 static inline void nova_memunlock_reserved(struct super_block *sb,
-					 struct nova_super_block *ps)
+					 struct nova_super_block *ps, unsigned long *flags)
 {
 	struct nova_sb_info *sbi = NOVA_SB(sb);
 
 	if (nova_is_protected(sb))
 		__nova_memunlock_range(ps,
-			sbi->head_reserved_blocks * NOVA_DEF_BLOCK_SIZE_4K);
+			sbi->head_reserved_blocks * NOVA_DEF_BLOCK_SIZE_4K, flags);
 }
 
 static inline void nova_memlock_reserved(struct super_block *sb,
-				       struct nova_super_block *ps)
+				       struct nova_super_block *ps, unsigned long *flags)
 {
 	struct nova_sb_info *sbi = NOVA_SB(sb);
 
 	if (nova_is_protected(sb))
 		__nova_memlock_range(ps,
-			sbi->head_reserved_blocks * NOVA_DEF_BLOCK_SIZE_4K);
+			sbi->head_reserved_blocks * NOVA_DEF_BLOCK_SIZE_4K, flags);
 }
 
-static inline void nova_memunlock_journal(struct super_block *sb)
+static inline void nova_memunlock_journal(struct super_block *sb, unsigned long *flags)
 {
 	void *addr = nova_get_block(sb, NOVA_DEF_BLOCK_SIZE_4K * JOURNAL_START);
 
@@ -143,48 +180,48 @@ static inline void nova_memunlock_journal(struct super_block *sb)
 		return;
 
 	if (nova_is_protected(sb))
-		__nova_memunlock_range(addr, NOVA_DEF_BLOCK_SIZE_4K);
+		__nova_memunlock_range(addr, NOVA_DEF_BLOCK_SIZE_4K, flags);
 }
 
-static inline void nova_memlock_journal(struct super_block *sb)
+static inline void nova_memlock_journal(struct super_block *sb, unsigned long *flags)
 {
 	void *addr = nova_get_block(sb, NOVA_DEF_BLOCK_SIZE_4K * JOURNAL_START);
 
 	if (nova_is_protected(sb))
-		__nova_memlock_range(addr, NOVA_DEF_BLOCK_SIZE_4K);
+		__nova_memlock_range(addr, NOVA_DEF_BLOCK_SIZE_4K, flags);
 }
 
 static inline void nova_memunlock_inode(struct super_block *sb,
-					 struct nova_inode *pi)
+					 struct nova_inode *pi, unsigned long *flags)
 {
 	if (nova_range_check(sb, pi, NOVA_INODE_SIZE))
 		return;
 
 	if (nova_is_protected(sb))
-		__nova_memunlock_range(pi, NOVA_INODE_SIZE);
+		__nova_memunlock_range(pi, NOVA_INODE_SIZE, flags);
 }
 
 static inline void nova_memlock_inode(struct super_block *sb,
-				       struct nova_inode *pi)
+				       struct nova_inode *pi, unsigned long *flags)
 {
 	/* nova_sync_inode(pi); */
 	if (nova_is_protected(sb))
-		__nova_memlock_range(pi, NOVA_INODE_SIZE);
+		__nova_memlock_range(pi, NOVA_INODE_SIZE, flags);
 }
 
-static inline void nova_memunlock_block(struct super_block *sb, void *bp)
+static inline void nova_memunlock_block(struct super_block *sb, void *bp, unsigned long *flags)
 {
 	if (nova_range_check(sb, bp, sb->s_blocksize))
 		return;
 
 	if (nova_is_protected(sb))
-		__nova_memunlock_range(bp, sb->s_blocksize);
+		__nova_memunlock_range(bp, sb->s_blocksize, flags);
 }
 
-static inline void nova_memlock_block(struct super_block *sb, void *bp)
+static inline void nova_memlock_block(struct super_block *sb, void *bp, unsigned long *flags)
 {
 	if (nova_is_protected(sb))
-		__nova_memlock_range(bp, sb->s_blocksize);
+		__nova_memlock_range(bp, sb->s_blocksize, flags);
 }
 
 

--- a/fs/nova/perf.c
+++ b/fs/nova/perf.c
@@ -364,6 +364,7 @@ static int nova_test_func_perf(struct super_block *sb, unsigned int func_id,
 	const memcpy_call_t *fmemcpy = NULL;
 	const checksum_call_t *fchecksum = NULL;
 	const raid5_call_t *fraid5 = NULL;
+	unsigned long irq_flags = 0;
 	INIT_TIMING(perf_time);
 
 	cpu = get_cpu(); /* get cpu id and disable preemption */
@@ -481,10 +482,10 @@ test:
 			err = fmemcpy->call(dst, pmem, off, size);
 		break;
 	case to_pmem_gid:
-		nova_memunlock_range(sb, pmem, poolsize);
+		nova_memunlock_range(sb, pmem, poolsize, &irq_flags);
 		for (i = 0; i < reps; i++, off += size)
 			err = fmemcpy->call(pmem, src, off, size);
-		nova_memlock_range(sb, pmem, poolsize);
+		nova_memlock_range(sb, pmem, poolsize, &irq_flags);
 		break;
 	case checksum_gid:
 		for (i = 0; i < reps; i++, off += size)

--- a/fs/nova/rebuild.c
+++ b/fs/nova/rebuild.c
@@ -144,13 +144,14 @@ static int nova_rebuild_inode_finish(struct super_block *sb,
 {
 	struct nova_inode *alter_pi;
 	u64 next;
+	unsigned long irq_flags = 0;
 
 	sih->i_size = le64_to_cpu(reb->i_size);
 	sih->i_mode = le64_to_cpu(reb->i_mode);
 	sih->i_flags = le32_to_cpu(reb->i_flags);
 	sih->trans_id = reb->trans_id + 1;
 
-	nova_memunlock_inode(sb, pi);
+	nova_memunlock_inode(sb, pi, &irq_flags);
 	nova_update_inode_with_rebuild(sb, reb, pi);
 	nova_update_inode_checksum(pi);
 	if (metadata_csum) {
@@ -158,7 +159,7 @@ static int nova_rebuild_inode_finish(struct super_block *sb,
 							sih->alter_pi_addr);
 		memcpy_to_pmem_nocache(alter_pi, pi, sizeof(struct nova_inode));
 	}
-	nova_memlock_inode(sb, pi);
+	nova_memlock_inode(sb, pi, &irq_flags);
 
 	/* Keep traversing until log ends */
 	curr_p &= PAGE_MASK;

--- a/fs/nova/symlink.c
+++ b/fs/nova/symlink.c
@@ -37,6 +37,7 @@ int nova_block_symlink(struct super_block *sb, struct nova_inode *pi,
 	char *blockp;
 	u32 time;
 	int ret;
+	unsigned long irq_flags = 0;
 
 	update.tail = sih->log_tail;
 	update.alter_tail = sih->alter_log_tail;
@@ -52,10 +53,10 @@ int nova_block_symlink(struct super_block *sb, struct nova_inode *pi,
 	block = nova_get_block_off(sb, name_blocknr, NOVA_BLOCK_TYPE_4K);
 	blockp = (char *)nova_get_block(sb, block);
 
-	nova_memunlock_block(sb, blockp);
+	nova_memunlock_block(sb, blockp, &irq_flags);
 	memcpy_to_pmem_nocache(blockp, symname, len);
 	blockp[len] = '\0';
-	nova_memlock_block(sb, blockp);
+	nova_memlock_block(sb, blockp, &irq_flags);
 
 	/* Apply a write entry to the log page */
 	time = current_time(inode).tv_sec;
@@ -70,9 +71,9 @@ int nova_block_symlink(struct super_block *sb, struct nova_inode *pi,
 		return ret;
 	}
 
-	nova_memunlock_inode(sb, pi);
+	nova_memunlock_inode(sb, pi, &irq_flags);
 	nova_update_inode(sb, inode, pi, &update, 1);
-	nova_memlock_inode(sb, pi);
+	nova_memlock_inode(sb, pi, &irq_flags);
 	sih->trans_id++;
 
 	return 0;


### PR DESCRIPTION
Fixes issue [#96](https://github.com/NVSL/linux-nova/issues/96).