### PR TITLE
Fix failure of block bitmap allocation on large NVM in failure recovery.

### DIFF
--- a/fs/nova/bbuild.c
+++ b/fs/nova/bbuild.c
@@ -666,7 +666,7 @@ static int nova_build_blocknode_map(struct super_block *sb,
 				(initsize >> (PAGE_SHIFT + 0x3));
 
 	/* Alloc memory to hold the block alloc bitmap */
-	final_bm->scan_bm_4K.bitmap = kzalloc(final_bm->scan_bm_4K.bitmap_size,
+	final_bm->scan_bm_4K.bitmap = kvzalloc(final_bm->scan_bm_4K.bitmap_size,
 							GFP_KERNEL);
 
 	if (!final_bm->scan_bm_4K.bitmap) {
@@ -703,7 +703,7 @@ static int nova_build_blocknode_map(struct super_block *sb,
 	ret = __nova_build_blocknode_map(sb, final_bm->scan_bm_4K.bitmap,
 			final_bm->scan_bm_4K.bitmap_size * 8, PAGE_SHIFT - 12);
 
-	kfree(final_bm->scan_bm_4K.bitmap);
+	kvfree(final_bm->scan_bm_4K.bitmap);
 	kfree(final_bm);
 
 	return ret;
@@ -718,9 +718,9 @@ static void free_bm(struct super_block *sb)
 	for (i = 0; i < sbi->cpus; i++) {
 		bm = global_bm[i];
 		if (bm) {
-			kfree(bm->scan_bm_4K.bitmap);
-			kfree(bm->scan_bm_2M.bitmap);
-			kfree(bm->scan_bm_1G.bitmap);
+			kvfree(bm->scan_bm_4K.bitmap);
+			kvfree(bm->scan_bm_2M.bitmap);
+			kvfree(bm->scan_bm_1G.bitmap);
 			kfree(bm);
 		}
 	}
@@ -747,11 +747,11 @@ static int alloc_bm(struct super_block *sb, unsigned long initsize)
 				(initsize >> (PAGE_SHIFT_1G + 0x3));
 
 		/* Alloc memory to hold the block alloc bitmap */
-		bm->scan_bm_4K.bitmap = kzalloc(bm->scan_bm_4K.bitmap_size,
+		bm->scan_bm_4K.bitmap = kvzalloc(bm->scan_bm_4K.bitmap_size,
 							GFP_KERNEL);
-		bm->scan_bm_2M.bitmap = kzalloc(bm->scan_bm_2M.bitmap_size,
+		bm->scan_bm_2M.bitmap = kvzalloc(bm->scan_bm_2M.bitmap_size,
 							GFP_KERNEL);
-		bm->scan_bm_1G.bitmap = kzalloc(bm->scan_bm_1G.bitmap_size,
+		bm->scan_bm_1G.bitmap = kvzalloc(bm->scan_bm_1G.bitmap_size,
 							GFP_KERNEL);
 
 		if (!bm->scan_bm_4K.bitmap || !bm->scan_bm_2M.bitmap ||

--- a/fs/nova/super.c
+++ b/fs/nova/super.c
@@ -776,8 +776,14 @@ setup_sb:
 	/* If the FS was not formatted on this mount, scan the meta-data after
 	 * truncate list has been processed
 	 */
-	if ((sbi->s_mount_opt & NOVA_MOUNT_FORMAT) == 0)
-		nova_recovery(sb);
+	if ((sbi->s_mount_opt & NOVA_MOUNT_FORMAT) == 0) {
+		retval = nova_recovery(sb);
+		if (retval < 0) {
+			nova_err(sb, "%s: nova recovery failed with return code %d\n",
+				__func__, retval);
+			goto out;
+		}
+	}
 
 	root_i = nova_iget(sb, NOVA_ROOT_INO);
 	if (IS_ERR(root_i)) {


### PR DESCRIPTION
Currently, the block bitmaps are allocated by ```kzalloc```. However, the maximum size of space it can allocate is finite(typically 4MiB). So if the size of NVM is big enough(>128GiB), the size of block bitmap will exceed the maximum size of space ```kzalloc``` can allocate, which will cause the failure of block bitmap allocation.

This PR fixes it by allocating block bitmaps with ```kvzalloc```.