### PR TITLE
Support and ignore MAP_SYNC

### DIFF
--- a/fs/nova/file.c
+++ b/fs/nova/file.c
@@ -920,6 +920,7 @@ const struct file_operations nova_dax_file_operations = {
 	.read_iter		= nova_dax_read_iter,
 	.write_iter		= nova_dax_write_iter,
 	.mmap			= nova_dax_file_mmap,
+	.mmap_supported_flags 	= MAP_SYNC,
 	.open			= nova_open,
 	.fsync			= nova_fsync,
 	.flush			= nova_flush,


### PR DESCRIPTION
To fix issue #99, we only need to add `MAP_SYNC` in the `mmap_supported_flags`. The following condition to indicate synchronous page fault by VFS does not change, so the execution path of page fault in mmap remains the same.
```c
// in fs/dax.c
/*
 * MAP_SYNC on a dax mapping guarantees dirty metadata is
 * flushed on write-faults (non-cow), but not read-faults.
 */
static bool dax_fault_is_synchronous(unsigned long flags,
		struct vm_area_struct *vma, struct iomap *iomap)
{
	return (flags & IOMAP_WRITE) && (vma->vm_flags & VM_SYNC)
		&& (iomap->flags & IOMAP_F_DIRTY);
}
``` 
IOMAP_F_DIRTY indicates the inode has uncommitted metadata requiring fdatasync, which will not be set by NOVA. So `dax_fault_is_synchronous` still returns 0 whether VM_SYNC is 0 or 1.