### PR TITLE
nova/Kconfig: Add LIBNVDIMM dependency

### DIFF
--- a/fs/nova/Kconfig
+++ b/fs/nova/Kconfig
@@ -1,6 +1,7 @@
 config NOVA_FS
 	tristate "NOVA: log-structured file system for non-volatile memories"
 	depends on FS_DAX
+	depends on LIBNVDIMM
 	select CRC32
 	select LIBCRC32C
 	help


### PR DESCRIPTION
```
Without it, compilation fails with:
ld: fs/nova/perf.o: in function `nd_fletcher64_call':
perf.c:(.text+0x510): undefined reference to `nd_fletcher64'
```