### PR TITLE
Fix crash consistency issue with alternate logs (#100)

### DIFF
--- a/fs/nova/log.c
+++ b/fs/nova/log.c
@@ -1184,7 +1184,6 @@ static int nova_initialize_inode_log(struct super_block *sb,
 		sih->log_pages++;
 		nova_flush_buffer(&pi->alter_log_head, CACHELINE_SIZE, 1);
 	}
-	nova_update_inode_checksum(pi);
 	nova_memlock_inode(sb, pi, &irq_flags);
 
 	return 0;
@@ -1220,6 +1219,10 @@ static u64 nova_extend_inode_log(struct super_block *sb, struct nova_inode *pi,
 							sih->alter_log_head);
 			nova_memlock_inode(sb, pi, &irq_flags);
 		}
+
+		nova_memunlock_inode(sb, pi, &irq_flags);
+		nova_update_inode_checksum(pi);
+		nova_memlock_inode(sb, pi, &irq_flags);
 
 		return sih->log_head;
 	}


### PR DESCRIPTION
This PR has a fix for the crash consistency bug described in issue #100. The issue could occur if the system crashed between initializing an inode's main and alternate logs. In the current version of NOVA, the inode's checksum is updated after the main log is initialized and again after the alternate log is initialized. Crashing between these updates can lead to a state where NOVA assumes that both logs are initialized, causing incorrect behavior. This fix moves the checksum update to occur after initialization of both logs, which prevents this issue.