### PR TITLE
Zero out nova info header, fix issue 115

### DIFF
--- a/fs/nova/bbuild.c
+++ b/fs/nova/bbuild.c
@@ -206,6 +206,8 @@ static int nova_init_blockmap_from_inode(struct super_block *sb)
 	u64 cpuid;
 	int ret = 0;
 
+	memset(&sih, 0, sizeof(struct nova_info_header));
+
 	/* FIXME: Backup inode for BLOCKNODE */
 	ret = nova_get_head_tail(sb, pi, &sih);
 	if (ret)


### PR DESCRIPTION
Fixes issue #115 by zeroing out the `nova_info_header` struct used in `nova_init_blockmap_from_inode` before is used, ensuring that fields that are not set will be taken as null pointers. 