### PR TITLE
Add fence to nova_update_entry_csum, fix issue #127

### DIFF
--- a/fs/nova/checksum.c
+++ b/fs/nova/checksum.c
@@ -204,7 +204,7 @@ void nova_update_entry_csum(void *entry)
 
 flush:
 	if (entry_len > 0)
-		nova_flush_buffer(entry, entry_len, 0);
+		nova_flush_buffer(entry, entry_len, 1);
 
 }
 


### PR DESCRIPTION
Fixes issue #127 by adding a fence to `nova_update_entry_csum()`.