### PR TITLE
Make rename atomic with respect to crashes

### DIFF
--- a/fs/nova/dir.c
+++ b/fs/nova/dir.c
@@ -379,7 +379,7 @@ static int nova_inplace_update_dentry(struct super_block *sb,
  * already been logged for consistency
  */
 int nova_remove_dentry(struct dentry *dentry, int dec_link,
-	struct nova_inode_update *update, u64 epoch_id)
+	struct nova_inode_update *update, u64 epoch_id, bool rename)
 {
 	struct inode *dir = dentry->d_parent->d_inode;
 	struct super_block *sb = dir->i_sb;
@@ -414,7 +414,7 @@ int nova_remove_dentry(struct dentry *dentry, int dec_link,
 
 	dir->i_mtime = dir->i_ctime = current_time(dir);
 
-	if (nova_can_inplace_update_dentry(sb, old_dentry, epoch_id)) {
+	if (!rename && nova_can_inplace_update_dentry(sb, old_dentry, epoch_id)) {
 		nova_inplace_update_dentry(sb, dir, old_dentry,
 						dec_link, epoch_id);
 		curr_entry = nova_get_addr_off(sbi, old_dentry);

--- a/fs/nova/journal.h
+++ b/fs/nova/journal.h
@@ -50,8 +50,8 @@ u64 nova_create_inode_transaction(struct super_block *sb,
 	int new_inode, int invalidate);
 u64 nova_create_rename_transaction(struct super_block *sb,
 	struct inode *old_inode, struct inode *old_dir, struct inode *new_inode,
-	struct inode *new_dir, struct nova_dentry *father_entry,
-	int invalidate_new_inode, int cpu);
+	struct inode *new_dir, struct nova_dentry *father_entry, struct nova_dentry *new_dentry, 
+	struct nova_dentry *old_dentry, int invalidate_new_inode, int cpu);
 u64 nova_create_logentry_transaction(struct super_block *sb,
 	void *entry, enum nova_entry_type type, int cpu);
 void nova_commit_lite_transaction(struct super_block *sb, u64 tail, int cpu);

--- a/fs/nova/nova.h
+++ b/fs/nova/nova.h
@@ -1021,7 +1021,7 @@ int nova_append_dir_init_entries(struct super_block *sb,
 int nova_add_dentry(struct dentry *dentry, u64 ino, int inc_link,
 	struct nova_inode_update *update, u64 epoch_id);
 int nova_remove_dentry(struct dentry *dentry, int dec_link,
-	struct nova_inode_update *update, u64 epoch_id);
+	struct nova_inode_update *update, u64 epoch_id, bool rename);
 int nova_invalidate_dentries(struct super_block *sb,
 	struct nova_inode_update *update);
 void nova_print_dir_tree(struct super_block *sb,


### PR DESCRIPTION
Fixes the both the original bug described in #116 and the additional bug described in my comment on that issue by ensuring that modifications to dentries are journaled during rename.